### PR TITLE
fix: Correctly initialize the campaign worker

### DIFF
--- a/api/workers/startWorker.ts
+++ b/api/workers/startWorker.ts
@@ -1,11 +1,30 @@
 import dotenv from 'dotenv';
-import { startWorker } from './campaignWorker.js';
+import { campaignWorker } from './campaignWorker.js';
 
-// Carrega as variáveis de ambiente
+// Load environment variables from .env file
 dotenv.config();
 
-// Inicia o worker
-startWorker().catch(error => {
-  console.error('Worker failed to start:', error);
-  process.exit(1);
+console.log('Initializing campaign worker process...');
+
+// The BullMQ worker is instantiated in campaignWorker.ts, so simply importing it
+// is enough to start it. The following listeners provide diagnostics.
+
+campaignWorker.on('ready', () => {
+  console.log('Campaign worker is connected to Redis and ready to process jobs.');
 });
+
+campaignWorker.on('error', (error) => {
+  console.error('Campaign worker encountered a critical error:', error);
+});
+
+console.log('Campaign worker process is running. Waiting for jobs...');
+
+// Graceful shutdown
+const shutdown = async () => {
+  console.log('Shutting down campaign worker...');
+  await campaignWorker.close();
+  process.exit(0);
+};
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);


### PR DESCRIPTION
This commit fixes a critical bug where the campaign worker process would crash on startup. The entry point script (`startWorker.ts`) was attempting to call a `startWorker` function that was removed during a previous refactoring.

The script has been updated to correctly import the `campaignWorker` instance from `campaignWorker.ts`. The simple act of importing this module initializes the BullMQ worker.

Additionally, diagnostic listeners for 'ready' and 'error' events, as well as graceful shutdown handlers, have been added to the startup script to improve robustness and observability.

This change, combined with the previous refactoring of the worker and UI, should fully resolve the campaign sending issues.