### PR TITLE
I've fixed the webhook URL generation to use your custom domain.

### DIFF
--- a/api/_lib/webhook/message-handler.ts
+++ b/api/_lib/webhook/message-handler.ts
@@ -10,7 +10,7 @@ const analyzeAndStoreSentiment = async (messageText: string, contactId: string):
     }
 
     try {
-        const host = process.env.API_URL || 'http://localhost:3000';
+        const host = process.env.APP_URL || 'http://localhost:3000';
         const response = await fetch(`${host}/api/analyze-sentiment`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,14 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
+        - VITE_APP_URL=${VITE_APP_URL}
         - VITE_SUPABASE_URL=${VITE_SUPABASE_URL}
         - VITE_SUPABASE_ANON_KEY=${VITE_SUPABASE_ANON_KEY}
     ports:
       - "5173:80"
     environment:
       - NODE_ENV=production
+      - VITE_APP_URL=${VITE_APP_URL}
       - VITE_SUPABASE_URL=${VITE_SUPABASE_URL}
       - VITE_SUPABASE_ANON_KEY=${VITE_SUPABASE_ANON_KEY}
     depends_on:
@@ -33,7 +35,7 @@ services:
       - PORT=3001
       - SUPABASE_URL=${SUPABASE_URL}
       - SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
-      - APP_URL=http://localhost:5173
+      - APP_URL=${APP_URL}
       # assegura uso do host do serviço redis
       - REDIS_URL=redis://redis:6379
     depends_on:

--- a/src/pages/Settings/MetaApiSettings.tsx
+++ b/src/pages/Settings/MetaApiSettings.tsx
@@ -65,7 +65,7 @@ const MetaApiSettings: React.FC = () => {
     }, [profile, updateProfile]);
 
     // Construir a URL completa do webhook
-    const webhookUrl = user ? `${window.location.origin}/api/webhook/${user.id}` : '';
+    const webhookUrl = user ? `${import.meta.env.VITE_APP_URL || window.location.origin}/api/webhook/${user.id}` : '';
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const { name, value } = e.target;


### PR DESCRIPTION
I found that the webhook URLs for your tests and triggers were being generated with `localhost` instead of the custom domain configured in Docker.

This was caused by a few issues in the code:

1. The `VITE_APP_URL` environment variable was not being passed to the frontend container during the build process.
2. The `APP_URL` environment variable was hardcoded to `localhost` in the `api` service.
3. The Meta webhook URL was constructed using `window.location.origin`, which can be unreliable, instead of the environment variable.
4. The `message-handler.ts` file was using `API_URL` instead of `APP_URL`.

I've fixed these issues by:

- Updating `docker-compose.yml` to correctly pass the `VITE_APP_URL` and `APP_URL` environment variables.
- Standardizing the webhook URL generation in the frontend to use `VITE_APP_URL`.
- Aligning the backend configuration to use `APP_URL`.