### PR TITLE
fix: Use VITE_APP_URL for webhook URL generation

### DIFF
--- a/src/pages/AutomationEditor/node-settings/TriggerSettings.tsx
+++ b/src/pages/AutomationEditor/node-settings/TriggerSettings.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
+import { API_BASE_URL } from '../../../services/api.js';
 import { NodeSettingsProps } from './common.js';
 import { Button } from '../../../components/common/Button.js';
 import { COPY_ICON, PLUS_ICON, TRASH_ICON } from '../../../components/icons/index.js';
@@ -40,7 +41,7 @@ const TriggerSettings: React.FC<NodeSettingsProps> = ({ node, onConfigChange, pr
     };
 
     const webhookPath = useMemo(() => `${profile?.webhook_path_prefix || profile?.id}__${node.id}`, [profile, node.id]);
-    const webhookUrl = `${import.meta.env.VITE_APP_URL || window.location.origin}/api/trigger/${webhookPath}`;
+    const webhookUrl = `${API_BASE_URL}/api/trigger/${webhookPath}`;
 
     const updateMapping = (updater: (draft: any[]) => any[]) => {
         const currentMapping = config.data_mapping || [];

--- a/src/pages/Settings/MetaApiSettings.tsx
+++ b/src/pages/Settings/MetaApiSettings.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { EditableProfile } from '../../types/index.js';
 import { Button } from '../../components/common/Button.js';
+import { API_BASE_URL } from '../../services/api.js';
 import { COPY_ICON } from '../../components/icons/index.js';
 import { useAuthStore } from '../../stores/authStore.js';
 import { cn } from '../../lib/utils.js';
@@ -65,7 +66,7 @@ const MetaApiSettings: React.FC = () => {
     }, [profile, updateProfile]);
 
     // Construir a URL completa do webhook
-    const webhookUrl = user ? `${import.meta.env.VITE_APP_URL || window.location.origin}/api/webhook/${user.id}` : '';
+    const webhookUrl = user ? `${API_BASE_URL}/api/webhook/${user.id}` : '';
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const { name, value } = e.target;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,7 +3,11 @@
  * Garante que todas as chamadas usem o domínio correto (VITE_APP_URL ou window.location.origin)
  */
 
-const API_BASE_URL = import.meta.env.VITE_APP_URL || window.location.origin;
+export const API_BASE_URL = import.meta.env.VITE_APP_URL;
+
+if (!API_BASE_URL) {
+  throw new Error("VITE_APP_URL is not defined. Please set it in your .env file.");
+}
 
 /**
  * Realiza uma requisição à API


### PR DESCRIPTION
This commit fixes a bug where webhook URLs were being generated with `localhost` in production environments. The issue was caused by using `window.location.origin` as a fallback for the `VITE_APP_URL` environment variable.

To fix this, I have:
- Removed the `window.location.origin` fallback in `src/services/api.ts`, `src/pages/AutomationEditor/node-settings/TriggerSettings.tsx`, and `src/pages/Settings/MetaApiSettings.tsx`.
- Made `VITE_APP_URL` the single source of truth for the application's base URL by exporting `API_BASE_URL` from `src/services/api.ts` and using it in the other files.
- Added a check in `src/services/api.ts` to throw an error if `VITE_APP_URL` is not set, which will make configuration issues more apparent.